### PR TITLE
Add two utility methods

### DIFF
--- a/scripts/itemMacro.js
+++ b/scripts/itemMacro.js
@@ -132,7 +132,7 @@ export function getActorMacroItems(_actorID) {
 }
 
 export function getTokenActorMacroItems(_tokenID) {
-    let actor = game.tokens.get(_tokenID);
+    let actor = game.actors.tokens[_tokenID];
     return actor.items.filter(item => hasMacro(item));
 }
 

--- a/scripts/itemMacro.js
+++ b/scripts/itemMacro.js
@@ -126,8 +126,13 @@ export async function runMacro(_actorID,_itemId) {
 
 // Helper function to get list of all actor items that have a macro attached.
 // This function doesn't work if the itemmacro is only on the token's/synthetic actor's item.
-export function getMacroItems(_actorID) {
+export function getActorMacroItems(_actorID) {
     let actor = game.actors.get(_actorID);
+    return actor.items.filter(item => hasMacro(item));
+}
+
+export function getTokenActorMacroItems(_tokenID) {
+    let actor = game.tokens.get(_tokenID);
     return actor.items.filter(item => hasMacro(item));
 }
 

--- a/scripts/itemMacro.js
+++ b/scripts/itemMacro.js
@@ -124,13 +124,15 @@ export async function runMacro(_actorID,_itemId) {
     executeMacro(item);
 }
 
-// Helper function to get list of all actor items that have a macro attached.
+// Helper function to get list of all real actor items that have a macro attached.
 // This function doesn't work if the itemmacro is only on the token's/synthetic actor's item.
 export function getActorMacroItems(_actorID) {
     let actor = game.actors.get(_actorID);
     return actor.items.filter(item => hasMacro(item));
 }
 
+// Helper function to get list of all token actor items that have a macro attached.
+// This function works if the itemmacro is only on the token's/synthetic actor's item.
 export function getTokenActorMacroItems(_tokenID) {
     let actor = game.actors.tokens[_tokenID];
     return actor.items.filter(item => hasMacro(item));

--- a/scripts/itemMacro.js
+++ b/scripts/itemMacro.js
@@ -76,12 +76,7 @@ async function setMacro(item, command)
 }
 async function checkMacro(item)
 {
-    if(item.getFlag('itemacro','macro') === undefined || item.getFlag('itemacro','macro').data.command === "")
-    {
-        return "";
-    }else{
-        return await item.getFlag('itemacro','macro.data.command');
-    }
+    return hasMacro(item) ? item.getFlag('itemacro', 'macro.data.command') : "";
 }
 async function executeMacro(item)
 {
@@ -127,6 +122,20 @@ export async function runMacro(_actorID,_itemId) {
     if (!item) return ui.notifications.warn (`That actor does not own an item by that ID.`);
 
     executeMacro(item);
+}
+
+// Helper function to get list of all actor items that have a macro attached.
+// This function doesn't work if the itemmacro is only on the token's/synthetic actor's item.
+export function getMacroItems(_actorID) {
+    let actor = game.actors.get(_actorID);
+    return actor.items.filter(item => hasMacro(item));
+}
+
+// undefined and "" are both falsey, so if either the flag is undefined or the command is empty, this equates to false
+// and setting flag the check means you don't need to run the getFlag command more than once.
+export function hasMacro(item) {
+    let flag = item.getFlag('itemacro', 'macro');
+    return flag && flag.data.command;
 }
 
 function createCommand(item)

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -62,7 +62,8 @@ Hooks.on('setup', () =>{
     });
     window.ItemMacro = {
         runMacro: itemacro.runMacro,
-        debug : itemacro.debug
+        getMacroItems: itemacro.getMacroItems,
+        hasMacro: itemacro.hasMacro
     };
     if(game.settings.get('itemacro','hotbar')){
         Hooks._hooks.hotbarDrop = [hotbarHandler].concat(Hooks._hooks.hotbarDrop || []);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -62,7 +62,8 @@ Hooks.on('setup', () =>{
     });
     window.ItemMacro = {
         runMacro: itemacro.runMacro,
-        getMacroItems: itemacro.getMacroItems,
+        getActorItems: itemacro.getActorMacroItems,
+        getTokenItems: itemacro.getTokenActorMacroItems,
         hasMacro: itemacro.hasMacro
     };
     if(game.settings.get('itemacro','hotbar')){


### PR DESCRIPTION
Adds three utility methods:

- hasMacro(item) just an easier-to-write way to confirm if an item has a macro or not.
- getActorItems(actorId) gets the list of items with a macro from the real actor
- getTokenActorItems(tokenId) gets the list of items with a macro from the synthetic actor (the list should normally be the same as the real actor, but just in case)