### PR TITLE
Add support for Monster Blocks sheet.

### DIFF
--- a/scripts/itemMacro.js
+++ b/scripts/itemMacro.js
@@ -287,7 +287,10 @@ export function changeButtons(app,html,data)
         itemImage.click(async (event) => {
             if(game.system.id==="swade") return;
 
-            let li = $(event.currentTarget).parents(".item");
+            let li;
+            if (app.constructor.name == "MonsterBlock5e") li = $(event.currentTarget);
+            else li = $(event.currentTarget).parents(".item");
+            
             if(String(li.attr("data-item-id")) === "undefined") return;
             let item = app.actor.getOwnedItem(String(li.attr("data-item-id")));
             let flags = item.data.flags.itemacro?.macro;


### PR DESCRIPTION
The Monster Blocks sheet stores the item ID of rollable items on the button itself, not a parent, so in traversing the DOM with `$(event.currentTarget).parents(".item");` Item Macro ends up missing it. Instead, for the Monster Blocks sheet, `li` actually *is* `event.currentTarget`.