### PR TITLE
Update module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
 	"minimumCoreVersion" : "0.8.0",
 	"compatibleCoreVersion": "0.8.8",
 	"esmodules" : ["scripts/hooks.js"],
-	"systems" : ["dnd5e", "sfrpg", "swade", "dungeonworld", "ose"],
+	"system" : ["dnd5e", "sfrpg", "swade", "dungeonworld", "ose"],
 	"languages" : [
 		{
 			"lang" : "en",


### PR DESCRIPTION
vtt logs are throwing warnings about still using systems in modules.json
[warn] Package itemmacro is using the old "systems" manifest key where a "system" key is expected