### PR TITLE
Adding support for Simple Worldbuilding system

### DIFF
--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
 	"minimumCoreVersion" : "0.8.0",
 	"compatibleCoreVersion": "9",
 	"esmodules" : ["scripts/hooks.js"],
-	"system" : ["dnd5e", "sfrpg", "swade", "dungeonworld", "ose", "demonlord"],
+	"system" : ["dnd5e", "sfrpg", "swade", "dungeonworld", "ose", "demonlord", "worldbuilding"],
 	"languages" : [
 		{
 			"lang" : "en",

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -109,8 +109,8 @@ export class helper{
       case "cyberpunk-red-core" :
         if(settings.value("defaultmacro")) cyberpunk.register_helper();
         break;
-	  case "worldbuilding" :
-	    if(settings.value("defaultmacro")) worldbuilding.register_helper();
+      case "worldbuilding" :
+	if(settings.value("defaultmacro")) worldbuilding.register_helper();
         break;
     }
     if(sheetHooks){
@@ -178,7 +178,7 @@ export class helper{
       case "cyberpunk-red-core" :
         if(settings.value("charsheet")) return cyberpunk.sheetHooks();
         break;
-	  case "worldbuilding" :
+      case "worldbuilding" :
         if(settings.value("charsheet")) return worldbuilding.sheetHooks();
         break;
     }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -7,6 +7,7 @@ import * as dungeonworld from "./systems/dungeonworld.js";
 import * as ose from "./systems/ose.js";
 import * as demonlord from "./systems/demonlord.js";
 import * as cyberpunk from "./systems/cyberpunk-red-core.js";
+import * as worldbuilding from "./systems/worldbuilding.js";
 
 export class helper{
   static register(){
@@ -108,6 +109,9 @@ export class helper{
       case "cyberpunk-red-core" :
         if(settings.value("defaultmacro")) cyberpunk.register_helper();
         break;
+	  case "worldbuilding" :
+	    if(settings.value("defaultmacro")) worldbuilding.register_helper();
+        break;
     }
     if(sheetHooks){
       Object.entries(sheetHooks).forEach(([preKey, obj])=> {
@@ -173,6 +177,9 @@ export class helper{
         break;
       case "cyberpunk-red-core" :
         if(settings.value("charsheet")) return cyberpunk.sheetHooks();
+        break;
+	  case "worldbuilding" :
+        if(settings.value("charsheet")) return worldbuilding.sheetHooks();
         break;
     }
   }

--- a/scripts/systems/worldbuilding.js
+++ b/scripts/systems/worldbuilding.js
@@ -13,9 +13,9 @@ export function register_helper()
     if (speaker.token) actor = game.actors.tokens[speaker.token];
     if (!actor) actor = game.actors.get(speaker.actor);
 	
-	// Find item
+    // Find item
     const item = actor ? actor.items.find(i => i.name === itemName) : null;
-	if (!item) return ui.notifications.warn(`Your controlled Actor does not have an item named ${itemName}`);  
+    if (!item) return ui.notifications.warn(`Your controlled Actor does not have an item named ${itemName}`);  
 
     // Trigger the item roll
     if(item.hasMacro() && settings.value("defaultmacro"))
@@ -27,9 +27,7 @@ export function register_helper()
 export function sheetHooks()
 {
   const renderSheets = {    
-    //SimpleActorSheet : ".item .rollable", // Only use this to overwrite the formula buttons on items
-	//SimpleActorSheet : ".item .item-image", // SWB item images don't have the item-image class
-	SimpleActorSheet : ".item .item-name",
+    	SimpleActorSheet : ".item .item-name",
   };
   const renderedSheets = {
   };

--- a/scripts/systems/worldbuilding.js
+++ b/scripts/systems/worldbuilding.js
@@ -1,0 +1,40 @@
+import { logger } from "../logger.js";
+import { settings } from "../settings.js";
+
+export function register_helper()
+{
+  logger.info(`Registering Simple Worldbuilding System Helpers`);
+  /*
+    Override
+  */
+  game.worldbuilding.rollItemMacro = (itemName) => {
+    const speaker = ChatMessage.getSpeaker();
+    let actor;
+    if (speaker.token) actor = game.actors.tokens[speaker.token];
+    if (!actor) actor = game.actors.get(speaker.actor);
+	
+	// Find item
+    const item = actor ? actor.items.find(i => i.name === itemName) : null;
+	if (!item) return ui.notifications.warn(`Your controlled Actor does not have an item named ${itemName}`);  
+
+    // Trigger the item roll
+    if(item.hasMacro() && settings.value("defaultmacro"))
+      return item.executeMacro();
+    return item.roll();
+  }
+}
+
+export function sheetHooks()
+{
+  const renderSheets = {    
+    //SimpleActorSheet : ".item .rollable", // Only use this to overwrite the formula buttons on items
+	//SimpleActorSheet : ".item .item-image", // SWB item images don't have the item-image class
+	SimpleActorSheet : ".item .item-name",
+  };
+  const renderedSheets = {
+  };
+
+  return { render : renderSheets, rendered : renderedSheets };
+}
+
+


### PR DESCRIPTION
Modifies the module.json and helper.js files. Adds worldbuilding.js.

module.json has the worldbuilding system added to list of supported systems.
helper.js has helpers and sheet hooks imported from worldbuilding.js.
worldbuilding.js adds system specific support for the worldbuilding system. It was created using the other system js files as a starting guideline. I didn't need to modify very much, namely just changed the html class for sheet hooks.