### PR TITLE
Tiny bugfix for SWB

### DIFF
--- a/scripts/systems/worldbuilding.js
+++ b/scripts/systems/worldbuilding.js
@@ -34,7 +34,7 @@ export function register_helper()
     /* If an item was dropped, handle it ourselves */
     if( data.type == 'Item' ) {
       const command = `game.worldbuilding.rollItemMacro('${data.data.name}')`;
-      let macro = game.macros.find(m => (m.name === data.name) && (m.command === command));
+      let macro = game.macros.find(m => (m.name === data.data.name) && (m.command === command));
       if (!macro) {
         macro = await Macro.create({
           name: data.data.name,


### PR DESCRIPTION
Super tiny bugfix. The path to the item's name is actually *data.data.name*, and there appears to have just been a minor error where one of the *data* fields was missing. This was causing the comparison to always fail as *data.name* is undefined.