### PR TITLE
PR: opening multiple item macros overrides any previous ones

### DIFF
--- a/scripts/ItemMacroConfig.js
+++ b/scripts/ItemMacroConfig.js
@@ -12,6 +12,10 @@ export class ItemMacroConfig extends MacroConfig{
     });
   }
 
+  get id(){
+    return `itemacro-config-${this.options.item.id}`;
+  }
+
   /*
     Override
   */


### PR DESCRIPTION
This PR gives each macro config a unique id, using the attached item's id, such that each editor is separate.