### PR TITLE
Allow players to edit macros in owned items that they didn't initially author

### DIFF
--- a/scripts/ItemMacroConfig.js
+++ b/scripts/ItemMacroConfig.js
@@ -56,6 +56,7 @@ export class ItemMacroConfig extends MacroConfig{
         scope : "global", 
         command, 
         author : game.user.id,
+        ownership : { "default" : 3 }
       }));
   }
 


### PR DESCRIPTION
Players are now able to view/edit the Item Macro of items they have ownership of, even if they aren't the original author. Fixes #56 