### PR TITLE
Enables macro flags saving

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       # Create a release for this specific version
       - name: Update Release with Files
         id: create_version_release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.12.0
         with:
           allowUpdates: true # Set this to false if you want to prevent updating existing releases
           name: ${{ github.event.release.name }}

--- a/scripts/ItemMacroConfig.js
+++ b/scripts/ItemMacroConfig.js
@@ -43,19 +43,20 @@ export class ItemMacroConfig extends MacroConfig{
     item.executeMacro(event);
   }
 
-  async updateMacro({ command, type }){
+  async updateMacro({ command, type, flags }){
     let item = this.options.item;
     let macro = item.getMacro();
 
     logger.debug("ItemMacroConfig.js | updateMacro  | ", {command, type, item, macro});
 
-    if(macro.command != command)
+    // if(macro.command != command)
       await item.setMacro(new Macro({
         name : item.name, 
         type, 
         scope : "global", 
         command, 
         author : game.user.id,
+        flags: flags
       }));
   }
 


### PR DESCRIPTION
Currently, this module doesn't save flags attached to macros which limits compatibility with other modules as https://github.com/mclemente/fvtt-advanced-macros or midi-qol

This pull request adds the flags to the macro being saved and allows saving even if no changes where made to the command itself but may have been made to the flags

This partially fixes https://github.com/Kekilla0/Item-Macro/issues/64